### PR TITLE
Update on Assert.sol to avoid warnings during "truffle test" command execution

### DIFF
--- a/build/Assert.sol
+++ b/build/Assert.sol
@@ -61,7 +61,7 @@ library Assert {
     string constant STRING_NULL = "";
 
     uint8 constant ZERO = uint8(byte('0'));
-    uint8 constant A = uint8(byte('a'));
+    uint8 constant A_CONSTANT = uint8(byte('a'));
 
     byte constant MINUS = byte('-');
 
@@ -1459,7 +1459,7 @@ library Assert {
         if (u < 10)
             return byte(u + ZERO);
         else if (u < 16)
-            return byte(u - 10 + A);
+            return byte(u - 10 + A_CONSTANT);
         else
             return 0;
     }


### PR DESCRIPTION
Using "A" as a name for a constant in Assert.sol triggered a warning on each function that was using "A" as parameter during the execution of the "truffle test" command (and there were quite many).
Note : These warnings do not appear on oldest version of node and npm. For example, no warning with node version v6.11.2 and npm v3.10.10 but a warning with npm 5.3.0 and node 8.4.0. 
The easiest way to remove the warning is to rename this "A" constant.